### PR TITLE
ConsulKV replication from single DC to Multiple DC

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -48,3 +48,11 @@ func init() {
 	fmt.Printf("Initalizeing Common")
 
 }
+
+//global consul config
+type ConsulConfig struct {
+	IsLeader    bool
+	DCEndpoint  string
+	StorePreFix string
+	DCName      string
+}

--- a/consulLib/ConsulClient.go
+++ b/consulLib/ConsulClient.go
@@ -1,0 +1,140 @@
+package consulLib
+
+import (
+	"log"
+	"runtime"
+	"strings"
+	"sync"
+
+	"time"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// global map struct for all the dc list
+// this will be populated only for the leader
+type globalDCMap struct {
+	*sync.Mutex
+	//here string is the node name for now.
+	// TODO: if two nodes on a WAN have the same name?
+	DCClientConnection map[string]*FederaConsulClient
+	AvalibleDCInfo     map[string]*api.AgentMember
+}
+
+//consul client connection
+type FederaConsulClient struct {
+	*api.Client
+	*api.KV
+	Name     string //this will have the dc name
+	IsLeader bool   //if this client is the leader
+	DClist   *globalDCMap
+}
+
+func NewglobalDCMap() *globalDCMap {
+	return &globalDCMap{Mutex: new(sync.Mutex),
+		DCClientConnection: make(map[string]*FederaConsulClient),
+		AvalibleDCInfo:     make(map[string]*api.AgentMember),
+	}
+}
+
+//this function to create the KV client object for the any DC's address passed.
+func NewFederaConsulClient(DcEndPoint string, DCName string, isLeader bool) (*FederaConsulClient, bool) {
+
+	var dcInfoMap *globalDCMap
+
+	log.Println("[INFO]NewFederaConsulClient: called")
+
+	defaultConfig := api.DefaultConfig()
+	if isLeader == true {
+		//populate the DC maps
+		dcInfoMap = NewglobalDCMap()
+	}
+	defaultConfig.Datacenter = DCName
+	defaultConfig.Address = DcEndPoint
+
+	log.Println("[INFO]NewFederaConsulClient:", defaultConfig)
+
+	dcClient, err := api.NewClient(defaultConfig)
+
+	if err != nil {
+		log.Println("GetDefaultFederaConsulClient cannot connect to the default ", err)
+		return nil, false
+	}
+
+	return &FederaConsulClient{Client: dcClient, Name: DCName, IsLeader: isLeader, DClist: dcInfoMap, KV: dcClient.KV()}, true
+}
+
+func (this *FederaConsulClient) CheckAndUpdateDCInfo(newAgentList []*api.AgentMember, localDcName string) {
+
+	//newAgentList returns a pointer so it can be assigned?
+	for index, dcAgents := range newAgentList {
+		if strings.HasSuffix(dcAgents.Name, localDcName) != true {
+			if _, ok := this.DClist.AvalibleDCInfo[dcAgents.Name]; !ok {
+				//memebrs not found
+				//get the connection
+				this.GetNewClientConn(newAgentList[index])
+			}
+		} else {
+			log.Println("Skipping local dc store", dcAgents.Name, localDcName)
+		}
+	}
+}
+
+func (this *FederaConsulClient) GetNewClientConn(newAgentList *api.AgentMember) {
+
+	log.Println("Data centre name ", newAgentList.Name)
+	//need to parse the node name out of DC name
+	newAgentList.Name = strings.Split(newAgentList.Name, ".")[1]
+	log.Println("after split Data centre name ", newAgentList.Name)
+	newDcClient, ok := NewFederaConsulClient(newAgentList.Addr+":"+"8500", newAgentList.Name, false)
+	if !ok {
+		log.Println("Error in getting client connection to ", newAgentList.Name, " Failed to update the DC map ")
+		return
+	}
+	this.DClist.Lock()
+	this.DClist.AvalibleDCInfo[newAgentList.Name] = newAgentList
+	this.DClist.DCClientConnection[newAgentList.Name] = newDcClient
+	this.DClist.Unlock()
+}
+
+//type NodeName string
+
+//gloablDCmap will hold the list of all the dc excluding the one on which this replicate is running
+
+//this should
+func (this *FederaConsulClient) PopulatetheGlobalDCMap() bool {
+
+	log.Println("[INFO] PopulatetheGlobalDCMap: Called")
+
+	clientAgent := this.Agent()
+	//get wan members from agent
+
+	localDCInfo, err := clientAgent.Self()
+
+	if err != nil {
+		log.Println("Error retrieving the local Client info", err)
+		return false
+	}
+
+	localDCName := localDCInfo["Config"]["Datacenter"].(string)
+	log.Println("[INFO] Localagent name", localDCName)
+	for {
+
+		dcMembers, err := clientAgent.Members(true)
+		if err != nil {
+			log.Println("err list from members", err)
+			return false
+		}
+
+		for range dcMembers {
+			//log.Println("List from all the dc's", val)
+		}
+
+		log.Println("CheckAndUpdateDCInfo called")
+		this.CheckAndUpdateDCInfo(dcMembers, localDCName)
+		<-time.After(10 * time.Second)
+		runtime.Gosched()
+	}
+
+	return true
+}

--- a/consulLib/ConsulKVLib.go
+++ b/consulLib/ConsulKVLib.go
@@ -1,0 +1,121 @@
+package consulLib
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+)
+
+type KVData struct {
+	api.KVPairs
+	*api.QueryMeta
+}
+
+const Prefix = "Fedra"
+
+//this file will have all the kv store warps/decorator
+//this will have the list of ClientKV for the uderlying client
+
+//poll the local store and updaet the other DC's
+// StorePreFix Federa
+// TODO:blockFetch to use cas for fetching only when a new change is avaliable in the KV store
+// This function will be called only by Leader of the consul replicate
+func (this *FederaConsulClient) PollAndUpdateKV(blockFetch bool) {
+
+	log.Println("[INFO] PollAndUpdateKV: KV store dosent exist")
+	for {
+
+		//read from local store
+		if data := this.GetList(Prefix); data != nil {
+			log.Println("[INFO] PollAndUpdateKV: Data received")
+			this.UpdateKVAcrossDcs(data)
+		} else {
+			log.Println("[INFO] PollAndUpdateKV: KV store dosent exist")
+		}
+		<-time.After(5 * time.Second)
+	}
+}
+
+func (this *FederaConsulClient) UpdateKVAcrossDcs(data *KVData) {
+	//TODO: expensive lock coz of nested loop
+	localWG := new(sync.WaitGroup)
+	this.DClist.Lock()
+	for _, dc := range this.DClist.DCClientConnection {
+		//update all the DC's KV store in seperate goroutines
+		localWG.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			for _, kvpair := range data.KVPairs {
+				dc.PutData(kvpair.Key, kvpair.Value)
+			}
+
+		}(localWG)
+		time.Sleep(5 * time.Second)
+	}
+	localWG.Wait()
+	this.DClist.Unlock()
+}
+
+//GetDataFromLocalKVStore this will be used by the non-leader gossiper module
+func (this *FederaConsulClient) GetDataFromLocalKVStore() {
+
+	go func() {
+		for {
+			kvData := this.GetList(Prefix)
+			if kvData != nil {
+				log.Println("Data from the local store")
+				for _, val := range kvData.KVPairs {
+					log.Println("Data from the Local store", val.Key, string(val.Value))
+				}
+			}
+			<-time.After(time.Second * 2)
+		}
+	}()
+}
+
+func (this *FederaConsulClient) GetData(key string) []byte {
+	data, Meta, err := this.KV.Get(key, nil)
+
+	if err != nil {
+		log.Println("Err in KV Get")
+	}
+
+	log.Println(data, Meta)
+
+	return data.Value
+}
+
+//WriteOptions can be used to override the datacenter
+
+//key should have the prefix
+func (this *FederaConsulClient) PutData(key string, value []byte) (error, bool) {
+	//writeMeta
+	_, err := this.Put(&api.KVPair{Key: Prefix + "/" + key, Value: value}, nil)
+	if err != nil {
+		log.Println("Error PutData: Unable to put data to", this.Name, err, *this.Client)
+		return err, false
+	}
+	return nil, true
+}
+
+func (this *FederaConsulClient) GetList(prefix string) *KVData {
+
+	newKVData := &KVData{}
+	KeyValuelist, KeyValueMeta, err := this.List(Prefix+"/", nil)
+	if err != nil {
+		log.Println("GetList failed", err, KeyValueMeta, this.Client)
+		return nil
+	}
+
+	newKVData.KVPairs = KeyValuelist
+	newKVData.QueryMeta = KeyValueMeta
+	log.Println("GetList the total len of data", len(newKVData.KVPairs))
+	for _, val := range newKVData.KVPairs {
+
+		log.Println(string(val.Key), string(val.Value), val)
+	}
+
+	return newKVData
+}

--- a/consulLib/consulLib.go
+++ b/consulLib/consulLib.go
@@ -1,0 +1,50 @@
+package consulLib
+
+import (
+	"log"
+
+	"../common"
+)
+
+/*func init() {
+
+}*/
+
+//InitConsul should have the consulDCAddr with port
+/*
+func InitConsul(isLeader bool, consulDCAddr string) {
+
+}*/
+
+//
+func Run(config *common.ConsulConfig, DCName string) {
+
+	//addr, err := net.LookupHost("0.0.0.0")
+	//log.Println(addr, err)
+
+	newConsulClient, ok := NewFederaConsulClient(config.DCEndpoint, DCName, config.IsLeader)
+
+	if !ok {
+		log.Println("Cannot start the Consul Client")
+		return
+	}
+
+	if config.IsLeader {
+
+		//read from the KV store and send to other dc list
+		//get the list of DC's
+		//get the KV store with the configured prefix
+		log.Println("[INFO]:Starting the consul replicate server")
+		go newConsulClient.PopulatetheGlobalDCMap()
+		go newConsulClient.PollAndUpdateKV(false)
+
+	} else {
+
+		log.Println("[INFO]:Starting the consul replicate Client")
+		go newConsulClient.GetDataFromLocalKVStore()
+
+	}
+	log.Println("waiting")
+	wait := make(chan bool)
+	<-wait
+}

--- a/first.json
+++ b/first.json
@@ -1,6 +1,11 @@
 {
-		"Name": "First",
+		"Name": "dc1_eu",
 			"ConfigType": "New",
 				"GPort": 4400,
-				"MasterEndPoint" : "10.145.208.117:5050"
+				"MasterEndPoint" : "10.145.208.117:5050",
+
+				"consulConfig": 
+				{ "isLeader" : true, "DCEndpoint" : "172.31.16.41:8500", "StorePreFix": "Federa" }
+
+				
 }

--- a/main.go
+++ b/main.go
@@ -7,10 +7,10 @@ import (
 	"io/ioutil"
 	"log"
 
-	"./glib"
-
 	"./anonlib"
 	"./common"
+	"./consulLib"
+	"./glib"
 	"./httplib"
 )
 
@@ -23,6 +23,7 @@ type GossiperConfig struct {
 	HTTPPort       string //Defaults to 8080 if otherwise specify explicitly
 	TCPPort        string //TCP port at which gossiper will bind and listen for anon module to connect to
 	GPort          int    //Port at which gossper should start
+	ConsulConfig   common.ConsulConfig
 }
 
 func NewGossiperConfig() GossiperConfig {
@@ -97,6 +98,9 @@ func main() {
 
 	//start mesos master poller
 	//go mesoslib.Run()
+
+	//start consul client
+	go consulLib.Run(&config.ConsulConfig, config.Name)
 
 	//Start the Policy Engine module
 	//PE.Run()


### PR DESCRIPTION
Consul KV initial changes to replicate from one single data source to multiple data source.
Currently, this library will connect to a particular DC and get the list of all the DC's.
Then will fetch data from the local KV store and push to all other DC's KV store.  
